### PR TITLE
Remove the Required CMake version in each subdir.

### DIFF
--- a/file/CMakeLists.txt
+++ b/file/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
 project(file)
 
 add_library(file)

--- a/lexer/CMakeLists.txt
+++ b/lexer/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
 project(lexer)
 
 add_library(lexer)

--- a/operator/CMakeLists.txt
+++ b/operator/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
 project(operator)
 
 add_library(operator)

--- a/parser/CMakeLists.txt
+++ b/parser/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
 project(parser)
 
 add_library(parser)

--- a/stringutil/CMakeLists.txt
+++ b/stringutil/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
 project(stringutil)
 
 add_library(stringutil)

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
 project(testing)
 
 # add_library(testing)

--- a/token/CMakeLists.txt
+++ b/token/CMakeLists.txt
@@ -1,4 +1,3 @@
-cmake_minimum_required(VERSION 3.10)
 project(token)
 
 add_library(token)


### PR DESCRIPTION
Changing one file (CMake version) is more efficient than modifying all the CMake version.
We can just modify root CMake's CMake minimum version to indicate what CMake should be used