### PR TITLE
Returns err msg of invalid char if invalid char is read by lexer

### DIFF
--- a/lexer/lexer.cpp
+++ b/lexer/lexer.cpp
@@ -1,6 +1,7 @@
 #include "lexer.hpp"
 
 #include <cctype>
+#include <sstream>
 #include <string>
 
 #include "file.hpp"
@@ -145,10 +146,12 @@ TokenPtr Lexer::NextToken() {
       }
       break;
     default:
-      throw WrongLexingException("No matching char in NextToken()");
+      std::stringstream ssInvalidTokMsg;
+      ssInvalidTokMsg << "Token: \'" << textqueue.front()
+                      << "\' is not allowed";
+      throw WrongLexingException(ssInvalidTokMsg.str());
       break;
   }
-  // textqueue.pop();
 
   return tokptr;
 }


### PR DESCRIPTION
For example, If `;` is read by lexer during tokenization, it will return an error message stating that it is a invalid char.

```
./AParser                                                                                                                                     
>>> 1 + 1;
Token( TokenType: Integer Value: '1' )
Token( TokenType: Whitespace Value: ' ' )
Token( TokenType: Operator Value: '+' )
Token( TokenType: Whitespace Value: ' ' )
Token( TokenType: Integer Value: '1' )
libc++abi: terminating due to uncaught exception of type WrongLexingException: Token: ';' is not allowed
[1]    14289 abort      ./AParser
```