### PR TITLE
Update from C++17 to C++20 with CMake Version Update from 3.10 to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,10 @@
-cmake_minimum_required(VERSION 3.10)
+# C++20 Requires 3.12, While C++23 Requires 3.20
+cmake_minimum_required(VERSION 3.20)
 project(AParser)
 
-# Set to C++17 Standard
+# Set to C++20 Standard
 set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
 
 # Include sub-directories
 add_subdirectory(file)


### PR DESCRIPTION
Migrating C++17 to C++20

C++20 requires CMake Version 3.12 minimum
C++23 requires CMake Version 3.20 minimum

Since some of the compilers does not support C++23 Std, the C++ Standard will be set to C++20

Reference 
- https://cmake.org/cmake/help/latest/prop_tgt/CXX_STANDARD.html