### PR TITLE
Read multiple punct converting to one op tok implementation

### DIFF
--- a/lexer/lexer.hpp
+++ b/lexer/lexer.hpp
@@ -22,6 +22,8 @@ class Lexer {
   // Parse the literal (variable/function naming)
   std::string readLiteral();
 
+  std::string readOp();
+
   std::string readWhitespace();
 
  public:

--- a/operator/operator.cpp
+++ b/operator/operator.cpp
@@ -1,32 +1,11 @@
 #include "operator.hpp"
 
+#include <sstream>
+
 Operator::Operator(std::string input) {
   this->value = input;
 
-  if (input == "+")
-    optype = OperatorType::PLUS;
-  else if (input == "-")
-    optype = OperatorType::MINUS;
-  else if (input == "*")
-    optype = OperatorType::STAR;
-  else if (input == "/")
-    optype = OperatorType::SLASH;
-  else if (input == "(")
-    optype = OperatorType::L_PARENTHESIS;
-  else if (input == ")")
-    optype = OperatorType::R_PARENTHESIS;
-  else if (input == "{")
-    optype = OperatorType::L_BRACE;
-  else if (input == "}")
-    optype = OperatorType::R_BRACE;
-  else if (input == "=")
-    optype = OperatorType::ASSIGN;
-  else if (input == "==")
-    optype = OperatorType::EQUAL;
-  else if (input == "!=")
-    optype = OperatorType::NOT_EQUAL;
-  else
-    optype = OperatorType::INVALID;
+  this->optype = GetOperatorType(input);
 
   fillOperatorMembers();
 }
@@ -59,6 +38,10 @@ void Operator::fillOperatorMembers() {
       precedence = 5;
       overloadable = false;
       break;
+    case OperatorType::NOT:
+      precedence = 5;
+      overloadable = true;
+      break;
     case OperatorType::L_PARENTHESIS:
     case OperatorType::R_PARENTHESIS:
       precedence = 4;
@@ -82,6 +65,38 @@ void Operator::fillOperatorMembers() {
       precedence = 7;
       overloadable = false;
   }
+}
+
+OperatorType Operator::GetOperatorType(std::string input) {
+  if (input == "+")
+    return OperatorType::PLUS;
+  if (input == "-")
+    return OperatorType::MINUS;
+  if (input == "*")
+    return OperatorType::STAR;
+  if (input == "/")
+    return OperatorType::SLASH;
+  if (input == "(")
+    return OperatorType::L_PARENTHESIS;
+  if (input == ")")
+    return OperatorType::R_PARENTHESIS;
+  if (input == "{")
+    return OperatorType::L_BRACE;
+  if (input == "}")
+    return OperatorType::R_BRACE;
+  if (input == "=")
+    return OperatorType::ASSIGN;
+  if (input == "==")
+    return OperatorType::EQUAL;
+  if (input == "!")
+    return OperatorType::NOT;
+  if (input == "!=")
+    return OperatorType::NOT_EQUAL;
+  
+  std::stringstream ssInvalidOpMsg;
+  ssInvalidOpMsg << "Operator: \'" << input
+                      << "\' is not allowed";
+  throw InvalidOperatorTypeException(ssInvalidOpMsg.str());
 }
 
 OperatorPtr GenerateOp(const std::string& input) {

--- a/operator/operator.hpp
+++ b/operator/operator.hpp
@@ -8,6 +8,7 @@ enum class OperatorType {
   // General
   ASSIGN,
   INVALID,
+  NOT,
 
   // Calculation
   PLUS,
@@ -42,10 +43,22 @@ class Operator {
   Operator(std::string input, OperatorType opType);
   ~Operator();
 
+  static OperatorType GetOperatorType(std::string input);
+
   OperatorType Type() const;
   std::string Text() const;
   bool IsOverloadable() const;
   int Precedence() const;
+};
+
+class InvalidOperatorTypeException : public std::exception {
+ private:
+  std::string errinfo;
+
+ public:
+  InvalidOperatorTypeException(std::string err) : errinfo(err){};
+
+  const char* what() const noexcept override { return errinfo.c_str(); }
 };
 
 typedef std::shared_ptr<Operator> OperatorPtr;


### PR DESCRIPTION
Read 1~2 punctuation converting to one operator token. if one punctuation is read and it is overloadable, but the next punct is not a compatible punctuation with the previous punctuation , then remove the punctuation and reallocate to another operator token.

Example
```C++
>>> !3 !=2 !!=2
Token( TokenType: Operator Value: '!' )
Token( TokenType: Integer Value: '3' )
Token( TokenType: Whitespace Value: ' ' )
Token( TokenType: Operator Value: '!=' )
Token( TokenType: Integer Value: '2' )
Token( TokenType: Whitespace Value: ' ' )
Token( TokenType: Operator Value: '!' )
Token( TokenType: Operator Value: '!=' )
Token( TokenType: Integer Value: '2' )
Token( TokenType: End of line Value: '' )
```