### PR TITLE
Debug mode for setting limit of printing token from one lexer. 

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,10 @@
 
 #include "lexer.hpp"
 
+// Set limit of printing token from one lexer
+#define DEBUG_SET_PRINT_LIMIT false
+#define PREVENT_LOOP_MAX_COUNT 10
+
 int main() {
   std::string input;
 
@@ -13,9 +17,18 @@ int main() {
     Lexer lexer = Lexer(input);
     TokenPtr tok;
 
+    #if DEBUG_SET_PRINT_LIMIT
+      int countLoop = 0;
+    #endif
+
     do {
       tok = lexer.NextToken();
       std::cout << *tok << std::endl;
+      
+      #if DEBUG_SET_PRINT_LIMIT
+        if(countLoop > PREVENT_LOOP_MAX_COUNT) break;
+        countLoop++;
+      #endif
     } while ((*tok).Type() != TokenType::EOL);
 
   } while (input != "exit");


### PR DESCRIPTION
This will prevent infinite loop printing. During lexing, if the lex counting goes wrong it will give result like this.

```
>>> ! 
...
Token( TokenType: Operator Value: '!' )
Token( TokenType: Operator Value: '!' )
Token( TokenType: Operator Value: '!' )
Token( TokenType: Operator Value: '!' )
Token( TokenType: Operator Value: '!' )
Token( TokenType: Operator Value: '!' )
Token( TokenType: Operator Value: '!' )
Token( TokenType: Operator Value: '!^C
```

To prevent the infinite loop of token printing from happening, this implementation is requested