### PR TITLE
Set C++ std to C++20 : Previous CMake C++ std incorrectly set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.20)
 project(AParser)
 
 # Set to C++20 Standard
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
 
 # Include sub-directories


### PR DESCRIPTION
Update the CMakeLists.txt file to correctly set the C++ standard to C++20.
Previously, the standard was incorrectly set to C++17 even though the compiler flag was set to C++20.