### PR TITLE
Getter for the operator member inside the Token class

### DIFF
--- a/token/token.cpp
+++ b/token/token.cpp
@@ -14,6 +14,8 @@ TokenType Token::Type() const { return toktype; }
 
 std::string Token::Text() const { return value; }
 
+OperatorPtr Token::OpPtr() const { return op; }
+
 std::string Token::PrintTokenType(TokenType toktype) {
   switch (toktype) {
     case TokenType::EOL:

--- a/token/token.hpp
+++ b/token/token.hpp
@@ -36,6 +36,7 @@ class Token {
 
   TokenType Type() const;
   std::string Text() const;
+  OperatorPtr OpPtr() const;
 
   static std::string PrintTokenType(TokenType toktype);
 


### PR DESCRIPTION
Previously there was no way to get the Operator member inside the Token class 
If the TokenType is Operator, we need to have a way to view the OperatorType to figure what operation it needs to perform during parser (ast) stage