### PR TITLE
Add whitespace expression

### DIFF
--- a/ast/ast.cpp
+++ b/ast/ast.cpp
@@ -16,6 +16,9 @@ std::string NodeEnumToString(NodeType nodetype) {
     case NodeType::BinaryExpr:
       typestr = "BinaryExpression";
       break;
+    case NodeType::WhitespaceExpr:
+      typestr = "WhitespaceExpression";
+      break;
     default:
       typestr = "InvalidExpression";
       break;
@@ -62,4 +65,12 @@ void IntegerExpression::PrintOstream(std::ostream& out) const {
   out << "Value : " << Value;
 
   out << ")";
+}
+
+void WhitespaceExpression::PrintOstream(std::ostream& out) const {
+  out << NodeEnumToString(Type()) << " (";
+
+  out << "Value : '" << Value;
+
+  out << "' )";
 }

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -16,6 +16,7 @@ enum class NodeType {
   IdentifierExpr,
   IntegerExpr,
   BinaryExpr,
+  WhitespaceExpr,
 };
 
 typedef std::shared_ptr<Statement> StatementPtr;
@@ -105,6 +106,24 @@ class IntegerExpression : public Expression {
   friend std::ostream& operator<<(std::ostream& out,
                                   const IntegerExpression& integerExpr) {
     integerExpr.PrintOstream(out);
+
+    return out;
+  }
+};
+
+class WhitespaceExpression : public Expression {
+ public:
+  WhitespaceExpression(std::string tokValue) : Value(tokValue){};
+
+  std::string Value;
+
+  NodeType Type() const override { return NodeType::WhitespaceExpr; }
+
+  void PrintOstream(std::ostream& out) const;
+
+  friend std::ostream& operator<<(std::ostream& out,
+                                  const WhitespaceExpression& whitespaceExpr) {
+    whitespaceExpr.PrintOstream(out);
 
     return out;
   }


### PR DESCRIPTION
Add whitespace detection to the AST node.

The whitespace token will be converted to whitespace expression and will be used for **strict syntax checking**

Ex.
```
// Require go like func syntax.
// Whitespace after the func identifier then the left brace
func main {
  hello()
}
```