### PR TITLE
Add multiplication/division and parenthesis calculation support

### DIFF
--- a/parser/parser.hpp
+++ b/parser/parser.hpp
@@ -10,13 +10,32 @@ class Parser {
  private:
   std::queue<TokenPtr> tokqueue;
 
+  // Preview the next token
+  TokenPtr peek();
+
+  // Check if the token matches the expected TokenType | OperatorType
+  // If it match, return TokenPtr
+  // Else throw Exception
+  TokenPtr expectedTokenType(TokenType expectedTokType);
+  TokenPtr expectedTokenType(OperatorType expectedOpType);
+
   // Return the peeked value and pops the tokqueue
   TokenPtr eat();
 
   StatementPtr parseStatement();
   ExpressionPtr parseExpression();
+
+  // Reads the token and assign the value as expression
   ExpressionPtr parsePrimaryExpression();
+
+  // + and - operations
   ExpressionPtr parseAdditionExpression();
+
+  // * and / operations
+  ExpressionPtr parseMultiplicationExpression();
+
+  // Read whitespaces if it exists
+  ExpressionPtr parseWhitespaceExpression();
 
  public:
   Parser(std::queue<TokenPtr> tokenQueue);


### PR DESCRIPTION
# Changes
- Support for Multiplication/Division (`Parser::parseMultiplicationExpression()`)
- Whitespace inside the calculation doesn't break the program (`Parser::parseWhitespaceExpression()`)
- Operator Precedence (Arithmetic Operation, Parenthesis Calculation)
- Refactoring the code (Make the repeatitive task (`peek()`, `expectedTokenType()`) into function