### PR TITLE
Add Null Expression for parsing

### DIFF
--- a/ast/ast.cpp
+++ b/ast/ast.cpp
@@ -74,3 +74,7 @@ void WhitespaceExpression::PrintOstream(std::ostream& out) const {
 
   out << "' )";
 }
+
+void NullExpression::PrintOstream(std::ostream& out) const {
+  out << NodeEnumToString(Type()) << " ( Value : 'NULL' )";
+}

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -17,6 +17,7 @@ enum class NodeType {
   IntegerExpr,
   BinaryExpr,
   WhitespaceExpr,
+  NullExpr,
 };
 
 typedef std::shared_ptr<Statement> StatementPtr;
@@ -124,6 +125,22 @@ class WhitespaceExpression : public Expression {
   friend std::ostream& operator<<(std::ostream& out,
                                   const WhitespaceExpression& whitespaceExpr) {
     whitespaceExpr.PrintOstream(out);
+
+    return out;
+  }
+};
+
+class NullExpression : public Expression {
+ public:
+  NullExpression(){};
+
+  NodeType Type() const override { return NodeType::NullExpr; }
+
+  void PrintOstream(std::ostream& out) const;
+
+  friend std::ostream& operator<<(std::ostream& out,
+                                  const NullExpression& nullExpr) {
+    nullExpr.PrintOstream(out);
 
     return out;
   }

--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -32,7 +32,7 @@ TokenPtr Parser::expectedTokenType(TokenType expectedTokType) {
 
   if (currtok->Type() == expectedTokType) return currtok;
   ssInvalidTokMsg << "Expected: \')\' Got Token: \'" << *(currtok)
-                    << "\' is not allowed";
+                  << "\' is not allowed";
 
   throw UnexpectedTokenParsedException(ssInvalidTokMsg.str());
 }
@@ -67,6 +67,10 @@ ExpressionPtr Parser::parsePrimaryExpression() {
       break;
     case TokenType::WHITESPACE:
       returnedExpr = ExpressionPtr(new WhitespaceExpression(eat()->Text()));
+      break;
+    case TokenType::NULLABLE:
+      eat();
+      returnedExpr = ExpressionPtr(new NullExpression());
       break;
     case TokenType::OPERATOR:
       switch (peek()->OpPtr()->Type()) {


### PR DESCRIPTION
# Changes
- Null Token will be used for Runtime Evalution (Interpretation stage after parsing). Previously #29 was for Token Detection. This Pull Request is for Parsing Stage

## Example
```
set hello = null;
```