### PR TITLE
Include null detection in AST NodeEnumToString func #30 Fix

### DIFF
--- a/ast/ast.cpp
+++ b/ast/ast.cpp
@@ -19,6 +19,9 @@ std::string NodeEnumToString(NodeType nodetype) {
     case NodeType::WhitespaceExpr:
       typestr = "WhitespaceExpression";
       break;
+    case NodeType::NullExpr:
+      typestr = "NullExpression";
+      break;
     default:
       typestr = "InvalidExpression";
       break;


### PR DESCRIPTION
# Changes
- When debugging `Null expression` , it showed null expression as `InvalidExpression`. #30 Fix

## Previous
```
./AParser 
>>> 1 + null
ProgramStatement {
BinaryExpression (Left Value : IntegerExpression (Value : 1), Op Value : +, Right Value : InvalidExpression ( Value : 'NULL' ), )
}
>>> null
ProgramStatement {
InvalidExpression ( Value : 'NULL' )
}
```

## Current
```
./AParser 
>>> null
ProgramStatement {
NullExpression ( Value : 'NULL' )
}
>>> 1 + 3 + null
ProgramStatement {
BinaryExpression (Left Value : BinaryExpression (Left Value : IntegerExpression (Value : 1), Op Value : +, Right Value : IntegerExpression (Value : 3), ), Op Value : +, Right Value : NullExpression ( Value : 'NULL' ), )
}
```