### PR TITLE
Change Program AST Statements vector to queue

### DIFF
--- a/ast/ast.cpp
+++ b/ast/ast.cpp
@@ -32,7 +32,11 @@ std::string NodeEnumToString(NodeType nodetype) {
 void Program::PrintOstream(std::ostream& out) const {
   out << NodeEnumToString(Type()) << " {\n";
 
-  for (const StatementPtr statement : Body) {
+  std::queue<StatementPtr> copiedProgram = Body;
+
+  while (!copiedProgram.empty()) {
+    StatementPtr statement = copiedProgram.front();
+    copiedProgram.pop();
     statement->PrintOstream(out);
     out << "\n";
   }

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -3,7 +3,6 @@
 
 #include <queue>
 #include <string>
-#include <vector>
 
 #include "token.hpp"
 
@@ -38,9 +37,10 @@ class Statement {
 
 class Program : public Statement {
  public:
-  Program() { Body = std::vector<StatementPtr>(); }
+  Program() { Body = std::queue<StatementPtr>(); }
+  Program(std::queue<StatementPtr> stmtVec) : Body(stmtVec){};
 
-  std::vector<StatementPtr> Body;
+  std::queue<StatementPtr> Body;
 
   NodeType Type() const override { return NodeType::Program; }
 

--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -41,7 +41,7 @@ Program Parser::ProduceAST() {
   Program program = Program();
 
   while (tokqueue.front()->Type() != TokenType::EOL) {
-    program.Body.push_back(parseStatement());
+    program.Body.push(parseStatement());
   }
 
   return program;


### PR DESCRIPTION
# Changes
- Change Program AST statement vector to queue

## Why?
After the parsing stage, then goes the Interpretation stage. Comparing the vector and queue, queue will be more efficient than vector. Since queue just requires `front()` and `pop()` to get the value and delete the value, while vector requires initializing index to get the value of the array.