### PR TITLE
Include runtime library and set main.cpp to print the evaluated result

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_subdirectory(ast)
 add_subdirectory(file)
 add_subdirectory(lexer)
 add_subdirectory(parser)
+add_subdirectory(runtime)
 add_subdirectory(stringutil)
 add_subdirectory(token)
 add_subdirectory(operator)
@@ -27,7 +28,7 @@ enable_testing()
 
 # Release Binary
 add_executable(AParser "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp")
-target_link_libraries(AParser PRIVATE token stringutil parser lexer file operator ast)
+target_link_libraries(AParser PRIVATE token stringutil parser lexer file operator ast runtime)
 target_compile_options(AParser PRIVATE -Wall -Wextra -Wpedantic -Werror)
 
 # Find clang-format executable

--- a/main.cpp
+++ b/main.cpp
@@ -4,6 +4,7 @@
 
 #include "lexer.hpp"
 #include "parser.hpp"
+#include "runtime.hpp"
 #include "token.hpp"
 
 // Set limit of printing token from one lexer
@@ -37,10 +38,15 @@ int main() {
 
     tokqueue.push(GenerateToken("", TokenType::EOL, OperatorPtr(nullptr)));
 
+    // Parse the token and produce Abstract Syntax Tree (AST)
     Parser parser = Parser(tokqueue);
     Program program = parser.ProduceAST();
 
-    std::cout << program << std::endl;
+    // Evaluate the AST and produce the result in string
+    Evaluater evaluater = Evaluater(program);
+    std::cout << evaluater.EvaluateProgram() << std::endl;
+
+    // Reset the token queue
     tokqueue = std::queue<TokenPtr>();
   } while (input != "exit");
 }


### PR DESCRIPTION
# Changes
- Remove printing the parsed result and print the evaluated result from the runtime library #34 . This will make the program prompt for the code and interpret and output the result.