### PR TITLE
Implement Identifier Declaration parsing and interpretation

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -14,10 +14,14 @@
 int main() {
   std::string input;
   std::queue<TokenPtr> tokqueue;
+  Parser parser = Parser();
+
+  Evaluater evaluater = Evaluater();
 
   do {
     std::cout << ">>> ";
     std::getline(std::cin, input);
+    if (input == "exit") return 0;
 
     Lexer lexer = Lexer(input);
     TokenPtr tok;
@@ -34,19 +38,23 @@ int main() {
       if (countLoop > PREVENT_LOOP_MAX_COUNT) break;
       countLoop++;
 #endif
-    } while ((*tok).Type() != TokenType::EOL);
+    } while (tok->Type() != TokenType::EOL);
+
+    // If null input, continue
+    if (tokqueue.front()->Type() == TokenType::EOL) {
+      tokqueue.pop();
+      continue;
+    }
 
     tokqueue.push(GenerateToken("", TokenType::EOL, OperatorPtr(nullptr)));
 
     // Parse the token and produce Abstract Syntax Tree (AST)
-    Parser parser = Parser(tokqueue);
-    Program program = parser.ProduceAST();
+    Program program = parser.ProduceAST(tokqueue);
 
     // Evaluate the AST and produce the result in string
-    Evaluater evaluater = Evaluater(program);
-    std::cout << evaluater.EvaluateProgram() << std::endl;
+    std::cout << evaluater.EvaluateProgram(program) << std::endl;
 
     // Reset the token queue
     tokqueue = std::queue<TokenPtr>();
-  } while (input != "exit");
+  } while (true);
 }

--- a/parser/parser.hpp
+++ b/parser/parser.hpp
@@ -37,11 +37,17 @@ class Parser {
   // Read whitespaces if it exists
   ExpressionPtr parseWhitespaceExpression();
 
+  // Declaration Identifier
+  StatementPtr parseIdentifierDeclarationExpression();
+
+  // Assignment Identifier
+  // ExpressionPtr parseIdentifierAssignmentExpression();
+
  public:
-  Parser(std::queue<TokenPtr> tokenQueue);
+  Parser();
   ~Parser();
 
-  Program ProduceAST();
+  Program ProduceAST(std::queue<TokenPtr>& tokenQueue);
 };
 
 class UnexpectedTokenParsedException : public std::exception {

--- a/runtime/runtime.hpp
+++ b/runtime/runtime.hpp
@@ -3,6 +3,7 @@
 
 #include <memory>
 #include <string>
+#include <unordered_map>
 
 #include "ast.hpp"
 
@@ -39,19 +40,33 @@ class NumberValue : public RuntimeValue {
 
 typedef std::shared_ptr<RuntimeValue> RuntimeValuePtr;
 
+class Environment {
+ private:
+  std::unordered_map<std::string, RuntimeValuePtr> variablemap;
+
+ public:
+  Environment();
+  void DefineVariable(std::string name, RuntimeValuePtr runtimeValue);
+  void AssignVariable(std::string name, RuntimeValuePtr runtimeValue);
+  RuntimeValuePtr GetRuntimeValue(std::string name);
+};
+
 class Evaluater {
  private:
   Program program;
+  Environment env;
 
   RuntimeValuePtr evaluateBinaryExpression(BinaryExpression binExpr);
   NumberValue evaluateNumericBinaryExpression(NumberValue lfs, NumberValue rhs,
                                               std::string op);
+  RuntimeValuePtr evaluateDefiningIdentifierExpression(
+      VariableDeclarationStatement varDeclStmt);
   RuntimeValuePtr evaluate(StatementPtr currStmt);
 
  public:
-  Evaluater(Program astProgram);
+  Evaluater();
 
-  std::string EvaluateProgram();
+  std::string EvaluateProgram(Program astProgram);
 };
 
 class UnexpectedStatementException : public std::exception {
@@ -60,6 +75,26 @@ class UnexpectedStatementException : public std::exception {
 
  public:
   UnexpectedStatementException(std::string err) : errinfo(err){};
+
+  const char* what() const noexcept override { return errinfo.c_str(); }
+};
+
+class VariableAlreadyDeclaredException : public std::exception {
+ private:
+  std::string errinfo;
+
+ public:
+  VariableAlreadyDeclaredException(std::string err) : errinfo(err){};
+
+  const char* what() const noexcept override { return errinfo.c_str(); }
+};
+
+class VariableDoesNotExistException : public std::exception {
+ private:
+  std::string errinfo;
+
+ public:
+  VariableDoesNotExistException(std::string err) : errinfo(err){};
 
   const char* what() const noexcept override { return errinfo.c_str(); }
 };


### PR DESCRIPTION
# Changes
- Implement IndentifierDeclaration parsing and interpretation (Parsing and interpretation stage using #36 )
- Receiving the `std::queue<TokenPtr>` and `Program` inside `parser` and `evaluator` constructor respectively now is received from the public function.
- Null input is now ignored (`main.cpp`). Previously null error was causing exception as there was no evaluator for that.

## Demo
```
./AParser
>>>
>>>
>>> set hello = 1
1
>>> hello * (7 * ( 7 * 7) )
343
```