### PR TITLE
Allow VariableDeclarationStmt's value be Expression than simple value

### DIFF
--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -171,7 +171,7 @@ StatementPtr Parser::parseIdentifierDeclarationExpression() {
   eat();
   parseWhitespaceExpression();
 
-  ExpressionPtr value = parsePrimaryExpression();
+  ExpressionPtr value = parseExpression();
   parseWhitespaceExpression();
 
   return std::make_shared<VariableDeclarationStatement>(varExpr->Name, value);


### PR DESCRIPTION
# Changes
- After PR #39, the identifier declaration did not support multiple expression, but just supported simple expression. Now allows multiple expression value in identifier declaration.

## Result
### Previous
```
./AParser 
>>> set a = 1 + 2
terminate called after throwing an instance of 'UnexpectedTokenParsedException'
  what():  Unexpected Operator: 'Operator( Value: '+' )' is not allowed
Aborted
```
### Now
```
./AParser 
>>> set a = 1+1
2
>>> a
2
>>> set b = 1 * 2 + 3
5
>>> b + a
7
```