### PR TITLE
Implement virtual destructor in classes where parent's virtual function is overriden (AppleClang compile error)

### DIFF
--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -51,11 +51,13 @@ class Program : public Statement {
   Program() { Body = std::queue<StatementPtr>(); }
   Program(std::queue<StatementPtr> stmtVec) : Body(stmtVec){};
 
+  virtual ~Program() = default;
+
   std::queue<StatementPtr> Body;
 
   NodeType Type() const override { return NodeType::Program; }
 
-  void PrintOstream(std::ostream& out) const;
+  void PrintOstream(std::ostream& out) const override;
 
   friend std::ostream& operator<<(std::ostream& out, const Program& program) {
     program.PrintOstream(out);
@@ -71,13 +73,15 @@ class BinaryExpression : public Expression {
   BinaryExpression(ExpressionPtr left, std::string op, ExpressionPtr right)
       : Left(left), Right(right), OP(op){};
 
+  virtual ~BinaryExpression() = default;
+
   ExpressionPtr Left;
   ExpressionPtr Right;
   std::string OP;
 
   NodeType Type() const override { return NodeType::BinaryExpr; }
 
-  void PrintOstream(std::ostream& out) const;
+  void PrintOstream(std::ostream& out) const override;
 
   friend std::ostream& operator<<(std::ostream& out,
                                   const BinaryExpression& binaryExpr) {
@@ -91,11 +95,13 @@ class IdentifierExpression : public Expression {
  public:
   IdentifierExpression(std::string name) : Name(name){};
 
+  virtual ~IdentifierExpression() = default;
+
   std::string Name;
 
   NodeType Type() const override { return NodeType::IdentifierExpr; }
 
-  void PrintOstream(std::ostream& out) const;
+  void PrintOstream(std::ostream& out) const override;
 
   friend std::ostream& operator<<(std::ostream& out,
                                   const IdentifierExpression& identifierExpr) {
@@ -109,11 +115,13 @@ class IntegerExpression : public Expression {
  public:
   IntegerExpression(int tokValue) : Value(tokValue){};
 
+  virtual ~IntegerExpression() = default;
+
   int Value;
 
   NodeType Type() const override { return NodeType::IntegerExpr; }
 
-  void PrintOstream(std::ostream& out) const;
+  void PrintOstream(std::ostream& out) const override;
 
   friend std::ostream& operator<<(std::ostream& out,
                                   const IntegerExpression& integerExpr) {
@@ -127,11 +135,13 @@ class WhitespaceExpression : public Expression {
  public:
   WhitespaceExpression(std::string tokValue) : Value(tokValue){};
 
+  virtual ~WhitespaceExpression() = default;
+
   std::string Value;
 
   NodeType Type() const override { return NodeType::WhitespaceExpr; }
 
-  void PrintOstream(std::ostream& out) const;
+  void PrintOstream(std::ostream& out) const override;
 
   friend std::ostream& operator<<(std::ostream& out,
                                   const WhitespaceExpression& whitespaceExpr) {
@@ -145,9 +155,11 @@ class NullExpression : public Expression {
  public:
   NullExpression(){};
 
+  virtual ~NullExpression() = default;
+
   NodeType Type() const override { return NodeType::NullExpr; }
 
-  void PrintOstream(std::ostream& out) const;
+  void PrintOstream(std::ostream& out) const override;
 
   friend std::ostream& operator<<(std::ostream& out,
                                   const NullExpression& nullExpr) {
@@ -167,12 +179,14 @@ class VariableDeclarationStatement : public Statement {
   VariableDeclarationStatement(std::string identifier, ExpressionPtr value)
       : Name(identifier), Value(value){};
 
+  virtual ~VariableDeclarationStatement() = default;
+
   std::string Name;
   ExpressionPtr Value;
 
   NodeType Type() const override { return NodeType::VariableDeclarationStmt; }
 
-  void PrintOstream(std::ostream& out) const;
+  void PrintOstream(std::ostream& out) const override;
 
   friend std::ostream& operator<<(
       std::ostream& out, const VariableDeclarationStatement& varDeclStmt) {
@@ -187,12 +201,14 @@ class VariableAssignExpression : public Expression {
   VariableAssignExpression(std::string identifier, StatementPtr value)
       : Name(identifier), Value(value){};
 
+  virtual ~VariableAssignExpression() = default;
+
   std::string Name;
   StatementPtr Value;
 
   NodeType Type() const override { return NodeType::VariableAssignExpr; }
 
-  void PrintOstream(std::ostream& out) const;
+  void PrintOstream(std::ostream& out) const override;
 
   friend std::ostream& operator<<(
       std::ostream& out, const VariableAssignExpression& varAssignStmt) {


### PR DESCRIPTION
# Changes
- Include `override` inside all the child class `PrintOstream` functions. #44 
- Implement virtual destructors in all child classes that contain `PrintOstream` functions. #44 

## Environment
MacOS Compiler Environment: `Apple clang version 15.0.0 (clang-1500.1.0.2.5)`

## Error Information
```
[ 53%] Built target runtime
[ 56%] Building CXX object CMakeFiles/AParser.dir/main.cpp.o
In file included from /Users/daehyung/Desktop/Programming/AParser/main.cpp:1:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/iostream:43:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/ios:221:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/__locale:18:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/mutex:191:
In file included from /Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/__memory/shared_ptr.h:31:
/Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/__memory/unique_ptr.h:65:5: error: delete called on non-final 'NullExpression' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
    delete __ptr;
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/__memory/unique_ptr.h:297:7: note: in instantiation of member function 'std::default_delete<NullExpression>::operator()' requested here
      __ptr_.second()(__tmp);
      ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/__memory/unique_ptr.h:263:75: note: in instantiation of member function 'std::unique_ptr<NullExpression>::reset' requested here
  _LIBCPP_INLINE_VISIBILITY _LIBCPP_CONSTEXPR_SINCE_CXX23 ~unique_ptr() { reset(); }
                                                                          ^
/Library/Developer/CommandLineTools/SDKs/MacOSX14.2.sdk/usr/include/c++/v1/__memory/shared_ptr.h:498:25: note: in instantiation of member function 'std::unique_ptr<NullExpression>::~unique_ptr' requested here
        unique_ptr<_Yp> __hold(__p);
                        ^
/Users/daehyung/Desktop/Programming/AParser/ast/ast.hpp:164:13: note: in instantiation of function template specialization 'std::shared_ptr<Expression>::shared_ptr<NullExpression, void>' requested here
    Value = ExpressionPtr(new NullExpression());
            ^
1 error generated.
make[2]: *** [CMakeFiles/AParser.dir/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/AParser.dir/all] Error 2
make: *** [all] Error 2
```