### PR TITLE
Link AParser language syntax docs to the root README #49

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ chmod +x AParser
 ./AParser
 ```
 
+## Learning Grammar Syntax of AParser
+Refer [AParser Language Syntax Documentation](https://github.com/daeisbae/AParser/blob/main/docs/README.md)
+
 ## Project Structure
 ```
 AParser


### PR DESCRIPTION
# Changes
- Link AParser language syntax docs (#56) to the root README (For Issue #49)