### PR TITLE
If 1 or more plus/minus op exist, evaluate the plus/minus symbol in parsing stage #60

### DIFF
--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -38,7 +38,7 @@ TokenPtr Parser::expectedTokenType(TokenType expectedTokType) {
   throw UnexpectedTokenParsedException(ssInvalidTokMsg.str());
 }
 
-Program Parser::ProduceAST(std::queue<TokenPtr> &tokenQueue) {
+Program Parser::ProduceAST(std::queue<TokenPtr>& tokenQueue) {
   tokqueue = tokenQueue;
   Program program = Program();
 
@@ -101,6 +101,23 @@ ExpressionPtr Parser::parsePrimaryExpression() {
           expectedTokenType(OperatorType::R_PARENTHESIS);
           eat();
           break;
+        case OperatorType::PLUS:
+        case OperatorType::MINUS: {
+          int sign = 1;
+          while (peek()->Type() == TokenType::OPERATOR &&
+                 (peek()->OpPtr()->Type() == OperatorType::PLUS ||
+                  peek()->OpPtr()->Type() == OperatorType::MINUS)) {
+            if (peek()->OpPtr()->Type() == OperatorType::MINUS) {
+              sign *= -1;
+            }
+            eat();
+            parseWhitespaceExpression();
+          }
+          expectedTokenType(TokenType::INTEGER);
+          returnedExpr = ExpressionPtr(
+              new IntegerExpression(sign * std::stoi(eat()->Text())));
+          break;
+        }
         default:
           ssInvalidTokMsg << "Unexpected Operator: \'" << *(peek()->OpPtr())
                           << "\' is not allowed";


### PR DESCRIPTION
# Changes
- Two or more plus/minus symbol before the Expression will be evaluated in parsing stage. ( `-1 * -1 = +1`, `-1 * +1 = -1`, `+1 * +1 = +1`) #60 

## Demo
```
 ./AParser                                                                                                                               ─╯
>>> +1 ----1
2
>>> -----11 ++---++--1
-12
>>> 1--1
2
>>> 1+-----1
0
```