### PR TITLE
Fix 1 == true expression that was caused due to Peek() and curr_tok mix up

### DIFF
--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -246,6 +246,7 @@ ExpressionPtr Parser::ParseComparisonExpression() {
     ParseWhitespaceExpression();
 
     left = ExpressionPtr(new ComparisonExpression(left, op_val, right));
+    next_tok = Peek();
   }
 
   return left;


### PR DESCRIPTION
# Changes
- Fix basic comparison expression (ex. 1 == true) error due to curr_tok not being updated in the loop #68 #70 

## Error Debugging
```
>>> set a = 1
1
>>> a == true
libc++abi: terminating due to uncaught exception of type UnexpectedTokenParsedException: Unexpected Token: 'Token( TokenType: End of line Value: '' )' is not allowed
Process 22727 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
    frame #0: 0x00000001918fea60 libsystem_kernel.dylib`__pthread_kill + 8
libsystem_kernel.dylib`:
->  0x1918fea60 <+8>:  b.lo   0x1918fea80               ; <+40>
    0x1918fea64 <+12>: pacibsp 
    0x1918fea68 <+16>: stp    x29, x30, [sp, #-0x10]!
    0x1918fea6c <+20>: mov    x29, sp
Target 0: (AParser) stopped.
(lldb) thread backtrace
* thread #1, queue = 'com.apple.main-thread', stop reason = signal SIGABRT
  * frame #0: 0x00000001918fea60 libsystem_kernel.dylib`__pthread_kill + 8
    frame #1: 0x0000000191936c20 libsystem_pthread.dylib`pthread_kill + 288
    frame #2: 0x0000000191843a30 libsystem_c.dylib`abort + 180
    frame #3: 0x00000001918edd08 libc++abi.dylib`abort_message + 132
    frame #4: 0x00000001918ddfa4 libc++abi.dylib`demangling_terminate_handler() + 320
    frame #5: 0x000000019157c1e0 libobjc.A.dylib`_objc_terminate() + 160
    frame #6: 0x00000001918ed0cc libc++abi.dylib`std::__terminate(void (*)()) + 16
    frame #7: 0x00000001918f0348 libc++abi.dylib`__cxxabiv1::failed_throw(__cxxabiv1::__cxa_exception*) + 88
    frame #8: 0x00000001918f028c libc++abi.dylib`__cxa_throw + 308
    frame #9: 0x00000001000178d0 AParser`Parser::ParsePrimaryExpression() + 3696
    frame #10: 0x0000000100018b88 AParser`Parser::ParseComparisonExpression() + 512
    frame #11: 0x00000001000167e0 AParser`Parser::ParseIdentifierAssignmentExpression() + 60
    frame #12: 0x0000000100016738 AParser`Parser::ParseExpression() + 32
    frame #13: 0x0000000100016490 AParser`Parser::ParseStatement() + 148
    frame #14: 0x00000001000162c8 AParser`Parser::ProduceAST(std::__1::queue<std::__1::shared_ptr<Token>, std::__1::deque<std::__1::shared_ptr<Token>, std::__1::allocator<std::__1::shared_ptr<Token>>>>&) + 152
    frame #15: 0x00000001000037d8 AParser`main + 588
    frame #16: 0x00000001915ae0e0 dyld`start + 2360
```