### PR TITLE
[#84] Git clone repository as the first instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ chmod +x AParser
 
 ### Docker Based Installation
 ```sh
+git clone https://github.com/daeisbae/AParser.git
 cd ~/Aparser
 docker build -t aparser .
 docker run --rm -it --name aparser aparser


### PR DESCRIPTION
# Changes
- Include git clone this repository to install through docker.