### PR TITLE
[#90] Make value return float if there is 0 after the decimal point, else convert to integer form

### DIFF
--- a/runtime/runtime.cpp
+++ b/runtime/runtime.cpp
@@ -108,9 +108,9 @@ RuntimeValuePtr Evaluater::EvaluateBinaryExpression(
 NumberValue Evaluater::EvaluateNumericBinaryExpression(NumberValue lhs,
                                                        NumberValue rhs,
                                                        std::string op) {
-  int result = 0;
-  int lhs_val = std::stoi(lhs.Value());
-  int rhs_val = std::stoi(rhs.Value());
+  double result = 0;
+  double lhs_val = std::stod(lhs.Value());
+  double rhs_val = std::stod(rhs.Value());
 
   if (op == "+") {
     result = lhs_val + rhs_val;

--- a/runtime/runtime.hpp
+++ b/runtime/runtime.hpp
@@ -26,13 +26,18 @@ class NullValue : public RuntimeValue {
 
 class NumberValue : public RuntimeValue {
  private:
-  int number_;
+  double number_;
 
  public:
-  NumberValue(int number) : number_(number){};
+  NumberValue(double number) : number_(number){};
 
   ValueType Type() const { return ValueType::NUMBER; }
-  std::string Value() const { return std::to_string(number_); }
+  std::string Value() const {
+    // check the floating point, if there is only 0 after the decimal point,
+    // convert to integer
+    return number_ == (int)number_ ? std::to_string((int)number_)
+                                   : std::to_string(number_);
+  }
 };
 
 class BooleanValue : public RuntimeValue {


### PR DESCRIPTION
# Changes
- Make value return float if there is 0 after the decimal point, else convert to integer form #90 
- Change the number value from int to double, so it can be more precise in arithmetic calculation. However, display in integer form if it doesn't have decimal point

## Problem
```
./AParser
>>> 1 - 1
0
>>> 1 / 3
0
>>> 1 / 5
0
```

## Demo
```
./AParser
>>> 1 - 1
0
>>> 1 -- 1
2
>>> 1 / 3
0.333333
>>> 1 / 5
0.200000
```