### PR TITLE
[#92] Integer TokenType and Expression changed to Number and change all number value from int to double

### DIFF
--- a/ast/ast.cpp
+++ b/ast/ast.cpp
@@ -19,8 +19,8 @@ std::string NodeEnumToString(NodeType node_type) {
     case NodeType::IdentifierExpr:
       type_str = "IdentifierExpression";
       break;
-    case NodeType::IntegerExpr:
-      type_str = "IntegerExpression";
+    case NodeType::NumberExpr:
+      type_str = "NumberExpression";
       break;
     case NodeType::BinaryExpr:
       type_str = "BinaryExpression";
@@ -114,7 +114,7 @@ void IdentifierExpression::PrintOstream(std::ostream &out) const {
   out << ")";
 }
 
-void IntegerExpression::PrintOstream(std::ostream &out) const {
+void NumberExpression::PrintOstream(std::ostream &out) const {
   out << NodeEnumToString(Type()) << " (";
 
   out << "Value : " << tok_value_;

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -14,7 +14,7 @@ class ComparisonExpression;
 class Expression;
 class BinaryExpression;
 class IdentifierExpression;
-class IntegerExpression;
+class NumberExpression;
 class WhitespaceExpression;
 class NullExpression;
 
@@ -28,7 +28,7 @@ enum class NodeType {
 
   // Expression
   IdentifierExpr,
-  IntegerExpr,
+  NumberExpr,
   BinaryExpr,
   WhitespaceExpr,
   BooleanExpr,
@@ -114,21 +114,21 @@ class IdentifierExpression : public Expression {
   }
 };
 
-class IntegerExpression : public Expression {
+class NumberExpression : public Expression {
  public:
-  IntegerExpression(int tok_value) : tok_value_(tok_value){};
+  NumberExpression(double tok_value) : tok_value_(tok_value){};
 
-  virtual ~IntegerExpression() = default;
+  virtual ~NumberExpression() = default;
 
-  int tok_value_;
+  double tok_value_;
 
-  NodeType Type() const override { return NodeType::IntegerExpr; }
+  NodeType Type() const override { return NodeType::NumberExpr; }
 
   void PrintOstream(std::ostream &out) const override;
 
   friend std::ostream &operator<<(std::ostream &out,
-                                  const IntegerExpression &int_expr) {
-    int_expr.PrintOstream(out);
+                                  const NumberExpression &num_expr) {
+    num_expr.PrintOstream(out);
 
     return out;
   }

--- a/lexer/lexer.cpp
+++ b/lexer/lexer.cpp
@@ -58,7 +58,17 @@ std::string Lexer::ReadStr() {
 std::string Lexer::ReadNum() {
   std::string num_val;
 
-  while (!text_queue_.empty() && std::isdigit(text_queue_.front())) {
+  // Used to check if there is double dot inside the number.
+  bool isDecimal = false;
+  while (!text_queue_.empty() &&
+         (std::isdigit(text_queue_.front()) || text_queue_.front() == '.')) {
+    if (isDecimal && text_queue_.front() == '.') {
+      std::stringstream ssInvalidStrMsg;
+      ssInvalidStrMsg << "Double value can't have two dot. Error in Original \""
+                      << num_val << "\" when adding \"" << text_queue_.front()
+                      << "\"";
+      throw WrongLexingException(ssInvalidStrMsg.str());
+    }
     num_val.push_back(text_queue_.front());
     text_queue_.pop();
   };
@@ -172,7 +182,7 @@ TokenPtr Lexer::NextToken() {
     case 48 ... 57:  // 0-9
       // Validate if it is number
       tok_ptr =
-          GenerateToken(ReadNum(), TokenType::INTEGER, OperatorPtr(nullptr));
+          GenerateToken(ReadNum(), TokenType::NUMBER, OperatorPtr(nullptr));
       break;
     case 65 ... 90:   // A-Z
     case 97 ... 122:  // a-z

--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -38,7 +38,7 @@ TokenPtr Parser::ExpectedTokenType(TokenType expected_type) {
   throw UnexpectedTokenParsedException(invalid_tok_msg.str());
 }
 
-Program Parser::ProduceAST(std::queue<TokenPtr>& tok_queue) {
+Program Parser::ProduceAST(std::queue<TokenPtr> &tok_queue) {
   tok_queue_ = tok_queue;
   Program program = Program();
 
@@ -77,9 +77,9 @@ ExpressionPtr Parser::ParsePrimaryExpression() {
     case TokenType::IDENTIFIER:
       returned_expr = ExpressionPtr(new IdentifierExpression(Eat()->Text()));
       break;
-    case TokenType::INTEGER:
+    case TokenType::NUMBER:
       returned_expr =
-          ExpressionPtr(new IntegerExpression(std::stoi(Eat()->Text())));
+          ExpressionPtr(new NumberExpression(std::stod(Eat()->Text())));
       break;
     case TokenType::WHITESPACE:
       returned_expr = ExpressionPtr(new WhitespaceExpression(Eat()->Text()));
@@ -114,9 +114,9 @@ ExpressionPtr Parser::ParsePrimaryExpression() {
             Eat();
             ParseWhitespaceExpression();
           }
-          ExpectedTokenType(TokenType::INTEGER);
+          ExpectedTokenType(TokenType::NUMBER);
           returned_expr = ExpressionPtr(
-              new IntegerExpression(sign * std::stoi(Eat()->Text())));
+              new NumberExpression(sign * std::stod(Eat()->Text())));
           break;
         }
         default:

--- a/runtime/runtime.cpp
+++ b/runtime/runtime.cpp
@@ -132,9 +132,9 @@ RuntimeValuePtr Evaluater::Evaluate(StatementPtr curr_stmt) {
     case NodeType::NullExpr:
       matchValue = std::make_unique<NullValue>();
       break;
-    case NodeType::IntegerExpr: {
-      std::shared_ptr<IntegerExpression> int_expr =
-          std::dynamic_pointer_cast<IntegerExpression>(curr_stmt);
+    case NodeType::NumberExpr: {
+      std::shared_ptr<NumberExpression> int_expr =
+          std::dynamic_pointer_cast<NumberExpression>(curr_stmt);
       if (!int_expr) {
         ss_invalid_stmt_msg
             << "Failed to cast StatementPtr to IntegerExpressionPtr : "

--- a/testing/test_lexer.cpp
+++ b/testing/test_lexer.cpp
@@ -45,7 +45,7 @@ TEST(LexerTest, AssignIntegerToVariable) {
 
   // 7
   EXPECT_EQ(*(test1.NextToken()),
-            *(GenerateToken("2", TokenType::INTEGER, OperatorPtr(nullptr))));
+            *(GenerateToken("2", TokenType::NUMBER, OperatorPtr(nullptr))));
 
   // 8
   EXPECT_EQ(*(test1.NextToken()),
@@ -113,7 +113,7 @@ TEST(LexerTest, Function) {
 
   // 14
   EXPECT_EQ(*(test1.NextToken()),
-            *(GenerateToken("123", TokenType::INTEGER, OperatorPtr(nullptr))));
+            *(GenerateToken("123", TokenType::NUMBER, OperatorPtr(nullptr))));
 
   // 15
   EXPECT_EQ(*(test1.NextToken()),

--- a/testing/test_runtime.cpp
+++ b/testing/test_runtime.cpp
@@ -4,9 +4,9 @@
 
 #include "runtime.hpp"
 
-TEST(EvaluaterTest, IntegerEvaluation) {
+TEST(EvaluaterTest, NumberEvaluation) {
   std::queue<StatementPtr> stmtqueue;
-  stmtqueue.push(std::make_shared<IntegerExpression>(1));
+  stmtqueue.push(std::make_shared<NumberExpression>(1));
 
   Evaluater test1 = Evaluater();
   std::string test1Result = test1.EvaluateProgram(stmtqueue);
@@ -54,8 +54,8 @@ TEST(EvaluaterTest, BinaryExpression) {
     std::queue<StatementPtr> stmtqueue;
     // 1 + 2
     stmtqueue.push(std::make_shared<BinaryExpression>(
-        std::make_shared<IntegerExpression>(1), "+",
-        std::make_shared<IntegerExpression>(2)));
+        std::make_shared<NumberExpression>(1), "+",
+        std::make_shared<NumberExpression>(2)));
 
     Evaluater test1 = Evaluater();
     std::string test1Result = test1.EvaluateProgram(stmtqueue);
@@ -67,8 +67,8 @@ TEST(EvaluaterTest, BinaryExpression) {
     std::queue<StatementPtr> stmtqueue2;
     // 0 - 2
     stmtqueue2.push(std::make_shared<BinaryExpression>(
-        std::make_shared<IntegerExpression>(0), "-",
-        std::make_shared<IntegerExpression>(2)));
+        std::make_shared<NumberExpression>(0), "-",
+        std::make_shared<NumberExpression>(2)));
 
     Evaluater test2 = Evaluater();
     std::string test2Result = test2.EvaluateProgram(stmtqueue2);
@@ -80,10 +80,10 @@ TEST(EvaluaterTest, BinaryExpression) {
     std::queue<StatementPtr> stmtqueue3;
     // 3 * ( 3 + 2 )
     stmtqueue3.push(std::make_shared<BinaryExpression>(
-        std::make_shared<IntegerExpression>(3), "*",
+        std::make_shared<NumberExpression>(3), "*",
         std::make_shared<BinaryExpression>(
-            std::make_shared<IntegerExpression>(3), "+",
-            std::make_shared<IntegerExpression>(2))));
+            std::make_shared<NumberExpression>(3), "+",
+            std::make_shared<NumberExpression>(2))));
 
     Evaluater test3 = Evaluater();
     std::string test3Result = test3.EvaluateProgram(stmtqueue3);
@@ -95,9 +95,9 @@ TEST(EvaluaterTest, BinaryExpression) {
     std::queue<StatementPtr> stmtqueue4;
     // 4 - ( 3 + null )
     stmtqueue4.push(std::make_shared<BinaryExpression>(
-        std::make_shared<IntegerExpression>(4), "-",
+        std::make_shared<NumberExpression>(4), "-",
         std::make_shared<BinaryExpression>(
-            std::make_shared<IntegerExpression>(3), "+",
+            std::make_shared<NumberExpression>(3), "+",
             std::make_shared<NullExpression>())));
 
     Evaluater test4 = Evaluater();
@@ -163,7 +163,7 @@ TEST(EvaluaterTest, BinaryExpression) {
     // true + 10
     stmtqueue9.push(std::make_shared<BinaryExpression>(
         std::make_shared<BooleanExpression>("true"), "+",
-        std::make_shared<IntegerExpression>(10)));
+        std::make_shared<NumberExpression>(10)));
 
     Evaluater test9 = Evaluater();
     std::string test9Result = test9.EvaluateProgram(stmtqueue9);
@@ -176,7 +176,7 @@ TEST(EvaluaterTest, BinaryExpression) {
     // false / 1
     stmtqueue10.push(std::make_shared<BinaryExpression>(
         std::make_shared<BooleanExpression>("false"), "/",
-        std::make_shared<IntegerExpression>(1)));
+        std::make_shared<NumberExpression>(1)));
 
     Evaluater test10 = Evaluater();
     std::string test10Result = test10.EvaluateProgram(stmtqueue10);
@@ -192,7 +192,7 @@ TEST(EvaluaterTest, VariableDeclaration) {
     // set hello = 1
     // hello
     stmtqueue.push(std::make_shared<VariableDeclarationStatement>(
-        "hello", std::make_shared<IntegerExpression>(1)));
+        "hello", std::make_shared<NumberExpression>(1)));
     stmtqueue.push(std::make_shared<IdentifierExpression>("hello"));
 
     Evaluater test1 = Evaluater();
@@ -237,9 +237,9 @@ TEST(EvaluaterTest, VariableAssignment) {
     // hello = 321
     // hello
     stmtqueue.push(std::make_shared<VariableDeclarationStatement>(
-        "hello", std::make_shared<IntegerExpression>(1)));
+        "hello", std::make_shared<NumberExpression>(1)));
     stmtqueue.push(std::make_shared<VariableAssignExpression>(
-        "hello", std::make_shared<IntegerExpression>(321)));
+        "hello", std::make_shared<NumberExpression>(321)));
     stmtqueue.push(std::make_shared<IdentifierExpression>("hello"));
 
     Evaluater test1 = Evaluater();
@@ -277,9 +277,9 @@ TEST(EvaluaterTest, VariableAssignment) {
     stmtqueue3.push(std::make_shared<VariableDeclarationStatement>(
         "testingVar2", std::make_shared<BooleanExpression>("false")));
     stmtqueue3.push(std::make_shared<VariableDeclarationStatement>(
-        "testingVar3", std::make_shared<IntegerExpression>(123)));
+        "testingVar3", std::make_shared<NumberExpression>(123)));
     stmtqueue3.push(std::make_shared<VariableAssignExpression>(
-        "testingVar2", std::make_shared<IntegerExpression>(521)));
+        "testingVar2", std::make_shared<NumberExpression>(521)));
     stmtqueue3.push(std::make_shared<VariableDeclarationStatement>(
         "testingVar4", std::make_shared<NullExpression>()));
     stmtqueue3.push(std::make_shared<IdentifierExpression>("testingVar2"));
@@ -297,8 +297,8 @@ TEST(EvaluaterTest, ValueComparison) {
     std::queue<StatementPtr> stmtqueue;
     // 1234 == 1234
     stmtqueue.push(std::make_shared<ComparisonExpression>(
-        std::make_shared<IntegerExpression>(1234),
-        "==", std::make_shared<IntegerExpression>(1234)));
+        std::make_shared<NumberExpression>(1234),
+        "==", std::make_shared<NumberExpression>(1234)));
 
     Evaluater test1 = Evaluater();
     std::string test1Result = test1.EvaluateProgram(stmtqueue);
@@ -310,8 +310,8 @@ TEST(EvaluaterTest, ValueComparison) {
     std::queue<StatementPtr> stmtqueue2;
     // 10 != 11
     stmtqueue2.push(std::make_shared<ComparisonExpression>(
-        std::make_shared<IntegerExpression>(10),
-        "!=", std::make_shared<IntegerExpression>(11)));
+        std::make_shared<NumberExpression>(10),
+        "!=", std::make_shared<NumberExpression>(11)));
 
     Evaluater test2 = Evaluater();
     std::string test2Result = test2.EvaluateProgram(stmtqueue2);
@@ -337,10 +337,10 @@ TEST(EvaluaterTest, ValueComparison) {
     // set hello = 1
     // hello == 1
     stmtqueue4.push(std::make_shared<VariableDeclarationStatement>(
-        "hello", std::make_shared<IntegerExpression>(1)));
+        "hello", std::make_shared<NumberExpression>(1)));
     stmtqueue4.push(std::make_shared<ComparisonExpression>(
         std::make_shared<IdentifierExpression>("hello"),
-        "==", std::make_shared<IntegerExpression>(1)));
+        "==", std::make_shared<NumberExpression>(1)));
 
     Evaluater test4 = Evaluater();
     std::string test4Result = test4.EvaluateProgram(stmtqueue4);
@@ -353,7 +353,7 @@ TEST(EvaluaterTest, ValueComparison) {
     // true == 1
     stmtqueue5.push(std::make_shared<ComparisonExpression>(
         std::make_shared<BooleanExpression>("true"),
-        "==", std::make_shared<IntegerExpression>(1)));
+        "==", std::make_shared<NumberExpression>(1)));
 
     Evaluater test5 = Evaluater();
     std::string test5Result = test5.EvaluateProgram(stmtqueue5);
@@ -366,7 +366,7 @@ TEST(EvaluaterTest, ValueComparison) {
     // false == 0
     stmtqueue6.push(std::make_shared<ComparisonExpression>(
         std::make_shared<BooleanExpression>("false"),
-        "==", std::make_shared<IntegerExpression>(0)));
+        "==", std::make_shared<NumberExpression>(0)));
 
     Evaluater test6 = Evaluater();
     std::string test6Result = test6.EvaluateProgram(stmtqueue6);
@@ -379,7 +379,7 @@ TEST(EvaluaterTest, ValueComparison) {
     // false == -1
     stmtqueue7.push(std::make_shared<ComparisonExpression>(
         std::make_shared<BooleanExpression>("false"),
-        "==", std::make_shared<IntegerExpression>(-1)));
+        "==", std::make_shared<NumberExpression>(-1)));
 
     Evaluater test7 = Evaluater();
     std::string test7Result = test7.EvaluateProgram(stmtqueue7);
@@ -391,7 +391,7 @@ TEST(EvaluaterTest, ValueComparison) {
     std::queue<StatementPtr> stmtqueue8;
     // -10 == false
     stmtqueue8.push(std::make_shared<ComparisonExpression>(
-        std::make_shared<IntegerExpression>(-10),
+        std::make_shared<NumberExpression>(-10),
         "==", std::make_shared<BooleanExpression>("false")));
 
     Evaluater test8 = Evaluater();
@@ -404,7 +404,7 @@ TEST(EvaluaterTest, ValueComparison) {
     std::queue<StatementPtr> stmtqueue9;
     // 123 != false
     stmtqueue9.push(std::make_shared<ComparisonExpression>(
-        std::make_shared<IntegerExpression>(123),
+        std::make_shared<NumberExpression>(123),
         "!=", std::make_shared<BooleanExpression>("false")));
 
     Evaluater test9 = Evaluater();

--- a/token/token.cpp
+++ b/token/token.cpp
@@ -28,8 +28,8 @@ std::string Token::PrintTokenType(TokenType tok_type) {
       return "Whitespace";
     case TokenType::SET:
       return "Set";
-    case TokenType::INTEGER:
-      return "Integer";
+    case TokenType::NUMBER:
+      return "Number";
     case TokenType::STRING:
       return "String";
     case TokenType::TRUE:

--- a/token/token.hpp
+++ b/token/token.hpp
@@ -13,7 +13,7 @@ enum class TokenType {
   IDENTIFIER,
   WHITESPACE,
   SET,
-  INTEGER,
+  NUMBER,
   STRING,
   TRUE,
   FALSE,


### PR DESCRIPTION
# Changes
- Integer TokenType and Expression changed to `TokenType::Number` and `NumberExpression` and change all number value from integer to double format #92 -> This was related to bug #90 

## Previous
```
./AParser
>>> 11 + 1.3333
12
>>> 1.5 + 14
15
```

## After Fix
```
./AParser                                                                                                                                                                                ─╯
>>> 11 + 1.3333
12.333300
>>> 1.5 + 14
15.500000
>>>
```