### PR TITLE
[#96] Implement String Expression, Value in AST, Parser, Runtime class

### DIFF
--- a/ast/ast.cpp
+++ b/ast/ast.cpp
@@ -34,6 +34,9 @@ std::string NodeEnumToString(NodeType node_type) {
     case NodeType::BooleanExpr:
       type_str = "BooleanExpression";
       break;
+    case NodeType::StringExpr:
+      type_str = "StringExpression";
+      break;
     default:
       type_str = "InvalidExpression";
       break;
@@ -137,4 +140,9 @@ void NullExpression::PrintOstream(std::ostream &out) const {
 void BooleanExpression::PrintOstream(std::ostream &out) const {
   out << NodeEnumToString(Type()) << " ( Value : '";
   out << boolean_ << "' )";
+}
+
+void StringExpression::PrintOstream(std::ostream &out) const {
+  out << NodeEnumToString(Type()) << " ( Value : '";
+  out << tok_value_ << "' )";
 }

--- a/ast/ast.hpp
+++ b/ast/ast.hpp
@@ -35,6 +35,7 @@ enum class NodeType {
   NullExpr,
   VariableAssignExpr,
   ComparisonExpr,
+  StringExpr,
 };
 
 std::string NodeEnumToString(NodeType node_type);
@@ -259,6 +260,26 @@ class ComparisonExpression : public Expression {
   friend std::ostream &operator<<(std::ostream &out,
                                   const ComparisonExpression &compare_expr) {
     compare_expr.PrintOstream(out);
+
+    return out;
+  }
+};
+
+class StringExpression : public Expression {
+ public:
+  StringExpression(std::string str) : tok_value_(str){};
+
+  std::string tok_value_;
+
+  virtual ~StringExpression() = default;
+
+  NodeType Type() const override { return NodeType::StringExpr; }
+
+  void PrintOstream(std::ostream &out) const override;
+
+  friend std::ostream &operator<<(std::ostream &out,
+                                  const StringExpression &str_expr) {
+    str_expr.PrintOstream(out);
 
     return out;
   }

--- a/parser/parser.cpp
+++ b/parser/parser.cpp
@@ -92,6 +92,9 @@ ExpressionPtr Parser::ParsePrimaryExpression() {
     case TokenType::FALSE:
       returned_expr = ExpressionPtr(new BooleanExpression(Eat()->Text()));
       break;
+    case TokenType::STRING:
+      returned_expr = ExpressionPtr(new StringExpression(Eat()->Text()));
+      break;
     case TokenType::OPERATOR:
       switch (Peek()->OpPtr()->Type()) {
         case OperatorType::L_PARENTHESIS:

--- a/runtime/runtime.cpp
+++ b/runtime/runtime.cpp
@@ -144,6 +144,18 @@ RuntimeValuePtr Evaluater::Evaluate(StatementPtr curr_stmt) {
       matchValue = std::make_unique<NumberValue>(int_expr->tok_value_);
       break;
     }
+    case NodeType::StringExpr: {
+      std::shared_ptr<StringExpression> string_expr =
+          std::dynamic_pointer_cast<StringExpression>(curr_stmt);
+      if (!string_expr) {
+        ss_invalid_stmt_msg
+            << "Failed to cast StatementPtr to StringExpressionPtr : "
+            << curr_stmt;
+        throw UnexpectedStatementException(ss_invalid_stmt_msg.str());
+      }
+      matchValue = std::make_unique<StringValue>(string_expr->tok_value_);
+      break;
+    }
     case NodeType::BinaryExpr: {
       std::shared_ptr<BinaryExpression> binary_expr =
           std::dynamic_pointer_cast<BinaryExpression>(curr_stmt);

--- a/runtime/runtime.hpp
+++ b/runtime/runtime.hpp
@@ -7,7 +7,7 @@
 
 #include "ast.hpp"
 
-enum class ValueType { NULLABLE, NUMBER, BOOLEAN };
+enum class ValueType { NULLABLE, NUMBER, BOOLEAN, STRING };
 
 class RuntimeValue {
  public:
@@ -49,6 +49,17 @@ class BooleanValue : public RuntimeValue {
 
   ValueType Type() const { return ValueType::BOOLEAN; }
   std::string Value() const { return boolean_; }
+};
+
+class StringValue : public RuntimeValue {
+ private:
+  std::string string_;
+
+ public:
+  StringValue(std::string string) : string_(string){};
+
+  ValueType Type() const { return ValueType::STRING; }
+  std::string Value() const { return string_; }
 };
 
 typedef std::shared_ptr<RuntimeValue> RuntimeValuePtr;


### PR DESCRIPTION
# Changes
- Implement String Expression, Value in AST, Parser, Runtime class. Previously, implemented until lexer. #96 

## Previous
```
./AParser
>>> set a = "Hello world"
libc++abi: terminating due to uncaught exception of type UnexpectedTokenParsedException: Unexpected Token: 'Token( TokenType: String Value: 'Hello world' )' is not allowed
[1]    84050 abort      ./AParser
```

## Demo
```
./AParser
>>> set a = "Hello avika"
Hello avika
>>> a
Hello avika
```