### PR TITLE
[#121] Implement README.md to doxygen main page

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1165,7 +1165,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE =
+USE_MDFILE_AS_MAINPAGE = README.md
 
 # The Fortran standard specifies that for fixed formatted Fortran code all
 # characters from position 72 are to be considered as comment. A common


### PR DESCRIPTION
# Changes
-  Implement README.md to doxygen main page (Previously showing empty main page) #121 

## Previous
<img width="1728" alt="Screenshot 2024-08-01 at 1 53 54 AM" src="https://github.com/user-attachments/assets/d7dc7e67-5a9d-440a-90aa-1ab0a6339dec">

## After
<img width="1728" alt="Screenshot 2024-08-01 at 1 55 29 AM" src="https://github.com/user-attachments/assets/5a5625a7-3752-4900-842a-dcb6a9cdcf52">
